### PR TITLE
Remove styling from Automation button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,9 +15,7 @@ export default function Home() {
       </div>
 
       <div className="mt-8 mb-8">
-        <button className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors duration-200">
-          Automation
-        </button>
+        <button>Automation</button>
       </div>
 
       <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left">


### PR DESCRIPTION
Simplified the Automation button by removing all CSS classes and styling.

Changes:
- Removed px-6 py-3 padding classes
- Removed bg-blue-600 background color
- Removed text-white text color
- Removed font-medium font weight
- Removed rounded-lg border radius
- Removed hover:bg-blue-700 hover state
- Removed transition-colors duration-200 animation

The button now uses default browser styling with only the text "Automation".

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/69c89e739b474272a2e88eaf18ff99c9/orbit-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>69c89e739b474272a2e88eaf18ff99c9</projectId>-->
<!--<branchName>orbit-space</branchName>-->