### PR TITLE
Change simple-button color scheme from blue to red

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,7 +32,7 @@ a {
 }
 
 .simple-button {
-  background-color: #0070f3;
+  background-color: #dc2626;
   color: white;
   border: none;
   padding: 12px 24px;
@@ -44,14 +44,14 @@ a {
 }
 
 .simple-button:hover {
-  background-color: #0056b3;
+  background-color: #b91c1c;
 }
 
 .simple-button:active {
-  background-color: #004494;
+  background-color: #991b1b;
 }
 
 .simple-button:focus {
-  outline: 2px solid #0070f3;
+  outline: 2px solid #dc2626;
   outline-offset: 2px;
 }


### PR DESCRIPTION
Updates the simple-button CSS class color scheme:

- Changes background-color from blue (#0070f3) to red (#dc2626)
- Updates hover state from #0056b3 to #b91c1c
- Updates active state from #004494 to #991b1b
- Updates focus outline from blue (#0070f3) to red (#dc2626)

All button states now use consistent red color variants instead of blue.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/7e6efadc77e249c0801f147338752926/vortex-world)

👀 [Preview Link](https://7e6efadc77e249c0801f147338752926-vortex-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>7e6efadc77e249c0801f147338752926</projectId>-->
<!--<branchName>vortex-world</branchName>-->