### PR TITLE
Remove simple-button className from Automation button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
       </div>
 
       <div className="mt-8 mb-8">
-        <button className="simple-button">Automation</button>
+        <button>Automation</button>
       </div>
 
       <div className="mb-32 grid text-center lg:max-w-5xl lg:w-full lg:mb-0 lg:grid-cols-4 lg:text-left">


### PR DESCRIPTION
Removed the "simple-button" className from the Automation button element in the home page component.

The button now uses default styling without the custom CSS class.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/4a75d750d9594a4c8b382905b62a1256/quantum-world)

👀 [Preview Link](https://4a75d750d9594a4c8b382905b62a1256-quantum-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>4a75d750d9594a4c8b382905b62a1256</projectId>-->
<!--<branchName>quantum-world</branchName>-->