### PR TITLE
Fix text content in main page component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ export default function Home() {
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
-          Get started by editing&nbsp;
+          <p>Get started by editings</p>
           <code className="font-mono font-bold">app/page.tsx</code>
         </p>
       </div>


### PR DESCRIPTION
## Purpose
Based on the conversation history, this change appears to be addressing visual changes to a builder element, likely to update or correct the text content displayed on the main page.

## Code changes
- Modified the text content in `app/page.tsx` from "Get started by editing&nbsp;" to wrap it in a `<p>` tag with "Get started by editings"
- Updated the structure of the introductory text element in the main page component
- Note: There appears to be a typo in the new text ("editings" instead of "editing")

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 22`

🔗 [Edit in Builder.io](https://builder.io/app/projects/90251212d24c4a688309423a1ef408c1/vortex-sanctuary)

👀 [Preview Link](https://90251212d24c4a688309423a1ef408c1-vortex-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>90251212d24c4a688309423a1ef408c1</projectId>-->
<!--<branchName>vortex-sanctuary</branchName>-->